### PR TITLE
Fix returning incoming transactions as sum of different currencies

### DIFF
--- a/src/main/java/com/fmi/relovut/services/TransactionService.java
+++ b/src/main/java/com/fmi/relovut/services/TransactionService.java
@@ -120,7 +120,7 @@ public class TransactionService {
         Map<Integer, List<TransactionChartDto>> incomingTransactionsDto = incomingTransactions.stream()
                 .map(trans ->  TransactionChartDto.builder()
                             .date(trans.getDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate().getDayOfMonth())
-                            .amount(trans.getAmount())
+                            .amount(GeneralHelper.round(trans.getAmount() * trans.getRate(), 2))
                             .build()
                 ).collect(Collectors.groupingBy(TransactionChartDto::getDate));
 


### PR DESCRIPTION
Fix returning incoming transactions as sum of different currencies instead of the account owner's currency